### PR TITLE
fix handling of empty environment

### DIFF
--- a/src/libc/crt0/crt1.c
+++ b/src/libc/crt0/crt1.c
@@ -128,31 +128,33 @@ char *__dos_argv0;
 static void
 setup_environment(void)
 {
-  char *dos_environ = alloca(_stubinfo->env_size), *cp;
+  char *dos_environ, *cp;
   short env_selector;
   int env_count=0;
+
+  dos_environ = alloca(_stubinfo->env_size);
   movedata(_stubinfo->psp_selector, 0x2c, ds, (int)&env_selector, 2);
   movedata(env_selector, 0, ds, (int)dos_environ, _stubinfo->env_size);
   cp = dos_environ;
-  do {
+  while (*cp) { /* repeat until two NULs */
     env_count++;
     while (*cp) cp++; /* skip to NUL */
     cp++; /* skip to next character */
-  } while (*cp); /* repeat until two NULs */
+  }
   _environ = (char **)malloc((env_count+1) * sizeof(char *));
   if (_environ == 0)
     return;
 
   cp = dos_environ;
   env_count = 0;
-  do {
+  while (*cp) { /* repeat until two NULs */
     /* putenv assumes each string is malloc'd */
     _environ[env_count] = (char *)malloc(strlen(cp)+1);
     strcpy(_environ[env_count], cp);
     env_count++;
     while (*cp) cp++; /* skip to NUL */
     cp++; /* skip to next character */
-  } while (*cp); /* repeat until two NULs */
+  }
   _environ[env_count] = 0;
 
   /*


### PR DESCRIPTION
Currently if the DOS environment is empty (can happen
when starting command.com), djgpp startup produces the
corrupted environment. This patch fixes it by checking
the loop end condition before loop action.