### PR TITLE
process: make descriptor leak work-around conditional

### DIFF
--- a/include/process.h
+++ b/include/process.h
@@ -52,6 +52,10 @@ int __djgpp_spawn(int _mode, const char *_path, char *const _argv[], char *const
 #define SPAWN_EXTENSION_SRCH    1
 #define SPAWN_NO_EXTENSION_SRCH 2
 
+#define __spawn_leak_workaround             0x0001 /* free descriptor leaks */
+
+extern int __spawn_flags;
+
 #endif /* !_POSIX_SOURCE */
 #endif /* !__STRICT_ANSI__ */
 #endif /* !__dj_ENFORCE_ANSI_FREESTANDING */

--- a/lib/dxe.ld
+++ b/lib/dxe.ld
@@ -31,5 +31,5 @@ SECTIONS {
     *(.bss .bss.* .gnu.linkonce.b.*)
     *(COMMON)
   }
-  /DISCARD/ : { *(gnu.lto_*) }
+  /DISCARD/ : { *(.gnu.lto_*) }
 }

--- a/src/debug/common/dbgcom.c
+++ b/src/debug/common/dbgcom.c
@@ -1338,13 +1338,13 @@ int invalid_sel_addr(short sel, unsigned a, unsigned len, char for_write)
     ("										\n\
       movw  %2,%%ax								\n\
       verr  %%ax								\n\
-      jnz   .Ldoes_not_has_read_right						\n\
+      jnz   .Ldoes_not_has_read_right%=					\n\
       movb  $1,%0								\n\
-.Ldoes_not_has_read_right:							\n\
+.Ldoes_not_has_read_right%=:							\n\
       verw  %%ax								\n\
-      jnz   .Ldoes_not_has_write_right						\n\
+      jnz   .Ldoes_not_has_write_right%=					\n\
       movb  $1,%1								\n\
-.Ldoes_not_has_write_right: "
+.Ldoes_not_has_write_right%=: "
      : "=qm" (read_allowed), "=qm" (write_allowed)
      : "g" (sel)
      );

--- a/src/dxe/makefile
+++ b/src/dxe/makefile
@@ -13,7 +13,8 @@ all :: native \
 	$(BIN)/dxe3res.exe \
 	$E
 
-native :: $(HOSTBIN)/dxegen.exe
+native :: $(HOSTBIN)/dxegen.exe \
+	$(HOSTBIN)/dxe3res.exe
 	$(NOP)
 
 .o.h:
@@ -35,6 +36,9 @@ $(BIN)/dxe3res.exe : $(C) dxe3res.o $(L)
 CROSS_CC = $(word 1,$(CROSS_GCC))
 $(HOSTBIN)/dxegen.exe : dxe3gen.c init1.h init2.h init3.h init4.h init5.h fini1.h fini2.h fini3.h fini4.h fini5.h
 	$(GCC) -DDXE_LD=\"$(CROSS_LD)\" -DDXE_CC=\"$(CROSS_CC)\" -DDXE_AR=\"$(CROSS_AR)\" -DDXE_AS=\"$(CROSS_AS)\" dxe3gen.c -o $@
+
+$(HOSTBIN)/dxe3res.exe: dxe3res.c
+	$(GCC) -O2 -Wall dxe3res.c -o $@
 
 clean ::
 	@-$(MISC) rm *.o *.h $(HOSTBIN)/dxegen.exe

--- a/src/libc/crt0/crt1.c
+++ b/src/libc/crt0/crt1.c
@@ -208,7 +208,7 @@ setup_os_version(void)
   _osminor = v & 0xff;
 }
 
-
+__attribute__((force_align_arg_pointer))
 void
 __crt1_startup(void)
 {

--- a/src/libc/dos/process/dosexec.c
+++ b/src/libc/dos/process/dosexec.c
@@ -45,6 +45,7 @@
 extern char **_environ;
 
 int __dosexec_in_system = 0;
+int __spawn_flags = __spawn_leak_workaround;
 
 typedef struct {
   unsigned short eseg;
@@ -492,7 +493,8 @@ static int direct_exec_tail (const char *program, const char *args,
     /* r5 as corresponding DPMI call is supported beginning with v5.  */
 
     ret = __dpmi_get_capabilities(&flags, dpmi_vendor);
-    if (ret == 0 && strcmp(dpmi_vendor + 2, "CWSDPMI") == 0)
+    if ((ret == 0 && strcmp(dpmi_vendor + 2, "CWSDPMI") == 0)
+        || (__spawn_flags & __spawn_leak_workaround) == 0)
       workaround_descriptor_leaks = 0;
     else
     {

--- a/src/makefile
+++ b/src/makefile
@@ -21,7 +21,7 @@ DIRS = \
 	../info		\
 	../lib
 
-all : misc.exe config $(DIRS) makemake.exe subs ../lib/libg.a ../lib/libpc.a
+all : misc.exe config $(DIRS) makemake.exe subs
 
 misc.exe : misc.c
 	gcc -O2 -Wall misc.c -o misc.exe

--- a/src/makefile.cfg
+++ b/src/makefile.cfg
@@ -55,6 +55,7 @@ gcc.opt: makefile.cfg
 	@./misc.exe echo - "-Wsign-compare" >>gcc.opt
 	@./misc.exe echo - "-nostdinc" >>gcc.opt
 	@./misc.exe echo - "$(IQUOTE)" >>gcc.opt
+	@./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc.opt
 
 
 gcc-l.opt: makefile.cfg
@@ -65,6 +66,7 @@ gcc-l.opt: makefile.cfg
 	@./misc.exe echo - "-Wall" >>gcc-l.opt
 	@./misc.exe echo - "-nostdinc" >>gcc-l.opt
 	@./misc.exe echo - "$(IQUOTE)" >>gcc-l.opt
+	@./misc.exe echo - "-mpreferred-stack-boundary=4" >>gcc-l.opt
 
 gpp.opt: gcc.opt
 	sed -f gpp.sed $< > $@

--- a/src/makefile.inc
+++ b/src/makefile.inc
@@ -165,7 +165,8 @@ ifneq ($(MAKEFILE_LIB),1)
 all :: makefile.oh
 makefile.oh : makefile
 	@$(MISC) echo - building new response file
-	@$(MISC) echo makefile.oh $(addprefix \&/,$(OBJS))
+	#@echo " $(addprefix $(subst $(abspath $(CURDIR)/$(TOP))/,,$(CURDIR)/),$(OBJS))" > makefile.oh
+	@echo "$(addprefix &/,$(OBJS))" > makefile.oh
 endif
 
 clean ::

--- a/src/makefile.lib
+++ b/src/makefile.lib
@@ -23,6 +23,7 @@ $(LIB)/lib$(LIBNAME).a : $(OBJS) makefile.rf $(TOP)/../ident.c
 ifeq ($(CROSS_BUILD),0)
 	$(CROSS_AR) q $(LIB)/lib$(LIBNAME).a @makefile.rf id_$(LIBNAME).o
 else
+	dos2unix makefile.rf
 	$(CROSS_AR) q $(LIB)/lib$(LIBNAME).a `cat makefile.rf` id_$(LIBNAME).o
 endif
 	$(CROSS_AR) s $(LIB)/lib$(LIBNAME).a

--- a/src/misc.c
+++ b/src/misc.c
@@ -14,7 +14,11 @@ main(int argc, char **argv)
 {
   /* MS-DOS uses \, unix uses / */
   if (argc > 2 && strcmp(argv[1], "mkdir") == 0)
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    mkdir(argv[2]);
+#else
     mkdir(argv[2], 0777);
+#endif
 
   /* redirection and long command lines don't always
      mix well under MS-DOS */

--- a/src/stub/exe2coff.c
+++ b/src/stub/exe2coff.c
@@ -5,10 +5,12 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <string.h>
-#include <io.h>
 #include <unistd.h>
 #include <ctype.h>
 
+#if !defined(O_BINARY)
+#define O_BINARY 0
+#endif
 
 static void
 exe2aout(char *fname)

--- a/src/stub/makefile
+++ b/src/stub/makefile
@@ -22,6 +22,7 @@ all :: native \
 native :: \
 	$(HOSTBIN)/stubedit.exe \
 	$(HOSTBIN)/stubify.exe \
+	$(HOSTBIN)/exe2coff.exe \
 	$(INC)/stubinfo.h \
 	$E
 	$(NOP)
@@ -63,10 +64,13 @@ $(BIN)/stubedit.exe : $(C) stubedit.o $(L)
 
 
 $(HOSTBIN)/stubify.exe : stubify.c stub.h
-	$(GCC) stubify.c -o $@
+	$(GCC) -O2 stubify.c -o $@
 
 $(HOSTBIN)/stubedit.exe : stubedit.c $(INC)/stubinfo.h
-	$(GCC) stubedit.c -o $@
+	$(GCC) -O2 stubedit.c -o $@
+
+$(HOSTBIN)/exe2coff.exe : exe2coff.c
+	$(GCC) -O2 $< -o $@
 
 ./stub2inc.exe : stub2inc.c
 	$(GCC) stub2inc.c -o $@


### PR DESCRIPTION
    This patch adds the __spawn_flags variable and __spawn_leak_workaround
    flag to allow the software to control the leak work-around.
    Previous behaviour was to always enable the work-around unless
    the DPMI host is cwsdpmi.
    
    Without this patch it is not possible to spawn a prot-mode TSR
    program like 32rtm. djgpp treats it as a leak and wipes out of
    memory. With this patch things work properly if the DPMI server
    is smart enough to direct the control to prev client after 32rtm
    TSRed. The problem is that 32rtm just jumps to the realmode exit
    addr, so the DPMI server doesn't see the exit and may get confused
    unless the special logic is implemented for that case (i.e. not all
    DPMI servers treat that correctly even after that patch).