### PR TITLE
stub: zero stalled stack and flags for fn 300h

### DIFF
--- a/src/stub/stub.asm
+++ b/src/stub/stub.asm
@@ -700,6 +700,10 @@ zero_regs:
 	ret
 
 pm_dos:
+	xor	ax, ax
+	mov	dpmi_regs[dr_ss], ax
+	mov	dpmi_regs[dr_sp], ax
+	mov	dpmi_regs[dr_efl], ax
 	mov	ax, 0x0300		; simulate interrupt
 	mov	bx, 0x0021		; int 21, no flags
 	xor 	cx, cx			; cx = 0x0000 (copy no args)


### PR DESCRIPTION
DPMI fn 300h calls realmode interrupt.
It takes the registers structure in es:edi.
If ss and sp in that structure are cleared, then DPMI provides
host's internal stack. DPMI then puts the registers at return,
to the same address, and that may include realmode ss/sp that DPMI
host provided for that call.

Unfortunately ss/sp were cleared only on first invocation.
As the result, subsequent invocations were putting the stack
to the same location as before, which is the DPMI host's private
location and should never be requested by client, even if in
most cases it doesn't change between calls.

This patch makes sure ss/sp and flags are always zeroed.
This is similar to how __dpmi_int() API works: it zeroes ss/sp
and flags.