### PR TITLE
dpmi: fix 0xd03 fn

### DIFF
--- a/src/libc/dpmi/api/d0d03.S
+++ b/src/libc/dpmi/api/d0d03.S
@@ -13,6 +13,6 @@
 	movl	ARG2, %edx
 
 	DPMI(0x0d03)
-	movzwl	%ax,%eax
+	xorl	%eax,%eax
 
 	LEAVE


### PR DESCRIPTION
It currently returns 0xd03 on success, but should return 0.