### PR TITLE
findfirst: support SFN fall-back

### DIFF
--- a/src/libc/dos/dir/findfirs.c
+++ b/src/libc/dos/dir/findfirs.c
@@ -104,9 +104,8 @@ findfirst(const char *pathname, struct ffblk *ffblk, int attrib)
       return 0;
     }
   }
-  else
+  /* else: not using LFN, or LFN unsupported for that drive */
   {
-
     #define _sizeof_dos_ffblk 44
     /* There will be a _sizeof_dos_ffblk character return value from findfirst 
        in the DTA.  Put the file name before this.  First set the DTA to be 


### PR DESCRIPTION
If some drive does not support LFN, SFN fall-back should be used.

This patch actually only adds the needed comment, as the code is already there.

Fixes https://github.com/dosemu2/dosemu2/issues/2786